### PR TITLE
feat(logger): add initHandler convenience initializer

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -2,10 +2,9 @@ const std = @import("std");
 const zlog = @import("zlog");
 
 pub fn main() !void {
-    // JSON handler
-    var json_handler = zlog.JsonHandler.init(zlog.stderr);
+    // Quick start — one-liner with initHandler
     const Log = zlog.Logger(.info, .{});
-    var logger = try Log.init(.{ .handler = json_handler.handler(), .allocator = std.heap.page_allocator });
+    var logger = try Log.initHandler(zlog.JsonHandler, .{}, .{ .allocator = std.heap.page_allocator });
     defer logger.deinit();
 
     logger.info("server started", .{ .port = 8080, .env = "prod" });
@@ -35,7 +34,7 @@ pub fn main() !void {
     // Source location — use Logger with .src = true and pass @src() as last argument
     const SrcLog = zlog.Logger(.info, .{ .src = true });
     {
-        var src_log = try SrcLog.init(.{ .handler = json_handler.handler(), .allocator = std.heap.page_allocator });
+        var src_log = try SrcLog.initHandler(zlog.JsonHandler, .{}, .{ .allocator = std.heap.page_allocator });
         defer src_log.deinit();
         src_log.info("checkpoint reached", .{ .step = "init" }, @src());
     }
@@ -56,16 +55,12 @@ pub fn main() !void {
     verbose_log.debug("this appears because of per-logger level override", .{});
 
     // JSON handler with RFC 3339 timestamps — human-readable ISO format
-    const Rfc3339Json = zlog.JsonHandler.Handler(.{ .timestamp = .rfc3339 });
-    var rfc3339_handler = Rfc3339Json.init(zlog.stderr);
-    var rfc3339_logger = try Log.init(.{ .handler = rfc3339_handler.handler(), .allocator = std.heap.page_allocator });
+    var rfc3339_logger = try Log.initHandler(zlog.JsonHandler, .{ .timestamp = .rfc3339 }, .{ .allocator = std.heap.page_allocator });
     defer rfc3339_logger.deinit();
     rfc3339_logger.info("human-readable timestamps", .{ .format = "RFC 3339" });
 
     // Text handler with RFC 3339 timestamps
-    const Rfc3339Text = zlog.TextHandler.Handler(.{ .timestamp = .rfc3339 });
-    var text_handler = Rfc3339Text.init(zlog.stderr);
-    var text_logger = try Log.init(.{ .handler = text_handler.handler(), .allocator = std.heap.page_allocator });
+    var text_logger = try Log.initHandler(zlog.TextHandler, .{ .timestamp = .rfc3339 }, .{ .allocator = std.heap.page_allocator });
     defer text_logger.deinit();
     text_logger.info("server started", .{ .port = 8080, .env = "prod" });
     text_logger.err("connection failed", .{ .host = "db.local", .err = error.TimedOut });
@@ -74,9 +69,7 @@ pub fn main() !void {
     text_logger.info("handled", .{ .request = .{ .method = "GET", .url = "/api" } });
 
     // Color handler with RFC 3339 timestamps — logrus-style colored output for terminals
-    const Rfc3339Color = zlog.ColorHandler.Handler(.{ .timestamp = .rfc3339 });
-    var color_handler = Rfc3339Color.init(zlog.stderr);
-    var color_logger = try Log.init(.{ .handler = color_handler.handler(), .allocator = std.heap.page_allocator });
+    var color_logger = try Log.initHandler(zlog.ColorHandler, .{ .timestamp = .rfc3339 }, .{ .allocator = std.heap.page_allocator });
     defer color_logger.deinit();
     color_logger.info("server started", .{ .port = 8080, .env = "prod" });
     color_logger.warn("slow response", .{ .duration_ms = 1200 });

--- a/src/Logger.zig
+++ b/src/Logger.zig
@@ -62,6 +62,46 @@ pub fn Logger(comptime min_level: Level, comptime opts: Options) type {
             };
         }
 
+        pub const HandlerInitOptions = struct {
+            writer: std.io.AnyWriter = fd.stderr,
+            middlewares: []const Middleware = &.{},
+            allocator: std.mem.Allocator,
+            level: ?*AtomicLevel = null,
+        };
+
+        /// Convenience initializer that creates the handler internally.
+        /// Accepts any handler module (e.g. `zlog.ColorHandler`, `zlog.JsonHandler`)
+        /// and its comptime config. The handler is allocated on the logger's arena
+        /// and freed automatically by `deinit()`.
+        ///
+        /// ```
+        /// var logger = try Log.initHandler(zlog.ColorHandler, .{ .timestamp = .rfc3339 }, .{
+        ///     .allocator = std.heap.page_allocator,
+        /// });
+        /// defer logger.deinit();
+        /// ```
+        pub fn initHandler(
+            comptime HandlerModule: type,
+            comptime handler_config: HandlerModule.Config,
+            init_opts: HandlerInitOptions,
+        ) !Self {
+            const shared = try init_opts.allocator.create(Shared);
+            shared.* = .{
+                .arena = std.heap.ArenaAllocator.init(init_opts.allocator),
+                .backing_allocator = init_opts.allocator,
+            };
+            const ConcreteHandler = HandlerModule.Handler(handler_config);
+            const concrete = try shared.arena.allocator().create(ConcreteHandler);
+            concrete.* = ConcreteHandler.init(init_opts.writer);
+            return .{
+                .handler = concrete.handler(),
+                .middlewares = init_opts.middlewares,
+                .shared = shared,
+                .level = init_opts.level,
+                .is_owner = true,
+            };
+        }
+
         /// Frees all memory owned by this logger and its children.
         /// Only call on the root logger (created via `init`). Never call on child
         /// loggers returned by `with()` or `withGroup()`.
@@ -354,6 +394,46 @@ pub fn Logger(comptime min_level: Level, comptime opts: Options) type {
             return count + 1;
         }
     };
+}
+
+test "initHandler creates logger with arena-owned handler" {
+    const testing = std.testing;
+    const json = @import("handlers/json.zig");
+    const Log = Logger(.info, .{});
+
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+
+    var logger = try Log.initHandler(json, .{}, .{
+        .writer = fbs.writer().any(),
+        .allocator = testing.allocator,
+    });
+    defer logger.deinit();
+
+    logger.info("hello", .{ .from = "initHandler" });
+    const output = fbs.getWritten();
+    try testing.expect(std.mem.indexOf(u8, output, "\"hello\"") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\"from\":\"initHandler\"") != null);
+}
+
+test "initHandler with custom config" {
+    const testing = std.testing;
+    const json = @import("handlers/json.zig");
+    const Log = Logger(.debug, .{});
+
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+
+    var logger = try Log.initHandler(json, .{ .timestamp = .rfc3339 }, .{
+        .writer = fbs.writer().any(),
+        .allocator = testing.allocator,
+    });
+    defer logger.deinit();
+
+    logger.info("test", .{});
+    const output = fbs.getWritten();
+    // RFC 3339 timestamps contain 'T' separator (e.g. 2024-01-01T00:00:00)
+    try testing.expect(std.mem.indexOf(u8, output, "T") != null);
 }
 
 test "logger comptime level filtering" {


### PR DESCRIPTION
Reduces the common 3-step handler setup (type → init → handler()) to a single call. The concrete handler is allocated on the logger's arena and freed automatically by deinit().